### PR TITLE
Fix typo in editor command error

### DIFF
--- a/src/editor/editorcommand.rs
+++ b/src/editor/editorcommand.rs
@@ -36,7 +36,7 @@ impl TryFrom<Event> for EditorCommand {
                 (KeyCode::End, _) => Ok(Self::Move(Direction::End)),
                 (KeyCode::PageUp, _) => Ok(Self::Move(Direction::PageUp)),
                 (KeyCode::PageDown, _) => Ok(Self::Move(Direction::PageDown)),
-                _ => Err(format!("Key COde not supported: {code:?}")),
+                _ => Err(format!("Key Code not supported: {code:?}")),
             },
             Event::Resize(width_u16, height_u16) => {
                 let height = height_u16 as usize;


### PR DESCRIPTION
## Summary
- correct typo in editor command error message

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6874981c13ec832989fc4e8d2ce767ed