### PR TITLE
Fix scrolling on resize

### DIFF
--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -42,7 +42,7 @@ impl View {
     pub fn resize(&mut self, to: Size) {
         self.size = to;
         // we need to ensure that the cursor is always in view
-        self.update_scroll_offset(to);
+        self.scroll_offset = self.update_scroll_offset(to);
         self.needs_redraw = true;
     }
 


### PR DESCRIPTION
## Summary
- store the new scroll offset returned by `update_scroll_offset` during window resize
- run `cargo check`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6874981b2e508329ae09405129c1968d